### PR TITLE
Run project build process

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -350,7 +350,7 @@ impl Aurora {
     }
 
     fn recover_from_wal(&self) -> Result<()> {
-        let entries = self.wal.lock().unwrap().recover()?;
+        let entries = self.wal.as_ref().unwrap().write().unwrap().recover()?;
 
         for entry in entries {
             match entry.operation {
@@ -374,7 +374,7 @@ impl Aurora {
             }
         }
 
-        self.wal.lock().unwrap().truncate()?;
+        self.wal.as_ref().unwrap().write().unwrap().truncate()?;
         Ok(())
     }
 


### PR DESCRIPTION
Fixed compilation errors by properly accessing RwLock through Option type.
- Changed self.wal.lock() to self.wal.as_ref().unwrap().write()
- RwLock requires .write() or .read() methods instead of .lock()
- Applied fix to both recover() and truncate() calls